### PR TITLE
Add nvs_flash_init to resolve system crash

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -7,6 +7,7 @@
 #include "esp_wifi.h"
 #include "esp_event_loop.h"
 #include "esp_log.h"
+#include "nvs_flash.h"
 
 #include "demo_application.h"
 
@@ -135,7 +136,8 @@ application_event_result application_event(application_request* request, unabto_
 void app_main()
 {
 
- 
+  nvs_flash_init();
+
   // disable the default wifi logging
   esp_log_level_set("wifi", ESP_LOG_NONE);
   


### PR DESCRIPTION
Error message - ESP_ERROR_CHECK failed: esp_err_t 0x1101 (ESP_ERR_NVS_NOT_INITIALIZED)